### PR TITLE
Inclusion of Changelogger - Another Small Tweak

### DIFF
--- a/templates/bin/class-tec-changelog-formatter.php
+++ b/templates/bin/class-tec-changelog-formatter.php
@@ -5,6 +5,7 @@
  * @package The Events Calendar
  */
 
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 use Automattic\Jetpack\Changelog\Changelog;
 use Automattic\Jetpack\Changelog\Parser;
 use Automattic\Jetpack\Changelogger\FormatterPlugin;


### PR DESCRIPTION
Added comment to disable phpcs checks for escaping outputs since this file should only be executed internally. This was getting flagged in [Events Calendar Pro's PR](https://github.com/the-events-calendar/events-pro/pull/2489)