### PR TITLE
Modify .editorconfig to add final newlines

### DIFF
--- a/templates/.editorconfig
+++ b/templates/.editorconfig
@@ -4,7 +4,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = tab
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true
 
 [**.{jshintrc,json,neon,scss-lint,yml}]


### PR DESCRIPTION
This PR updates the `.editorconfig` file to change `insert_final_newline` from `false` to `true`.

This comes after a [discussion in Slack](https://lw.slack.com/archives/C01H7Q57P1C/p1721336964462459) where multiple people thought it would be good to update this value to better match how we work.

