### PR TITLE
Update actions to use the `main` branch rather than the `master` branch.

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -57,14 +57,14 @@ group:
       - source: templates/workflows/changelogger.yml
         dest: .github/workflows/changelogger.yml
     repos: |
-      the-events-calendar/tribe-common@master
-      the-events-calendar/the-events-calendar@master
-      the-events-calendar/events-pro@master
-      the-events-calendar/events-eventbrite@master
-      the-events-calendar/events-community@master
-      the-events-calendar/events-filterbar@master
-      the-events-calendar/event-tickets@master
-      the-events-calendar/event-tickets-plus@master
+      the-events-calendar/tribe-common@main
+      the-events-calendar/the-events-calendar@main
+      the-events-calendar/events-pro@main
+      the-events-calendar/events-eventbrite@main
+      the-events-calendar/events-community@main
+      the-events-calendar/events-filterbar@main
+      the-events-calendar/event-tickets@main
+      the-events-calendar/event-tickets-plus@main
 
   # Promoter
   - files:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:

--- a/templates/bin/check-changelog.sh
+++ b/templates/bin/check-changelog.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BASE=${1-origin/master}
+BASE=${1-origin/main}
 HEAD=${2-HEAD}
 
 # Get only added files from git diff.

--- a/templates/workflows/changelogger.yml
+++ b/templates/workflows/changelogger.yml
@@ -3,7 +3,7 @@ name: Check changelog
 on:
   pull_request:
     branches:
-      - master
+      - main
       - 'release/**'
     paths-ignore:
       - '.github/**'

--- a/templates/workflows/release-merge-forward.yml
+++ b/templates/workflows/release-merge-forward.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       forward-branch:
-        description: 'Name of the branch to merge into (e.g. release/T25.adamwarlock, master)'
+        description: 'Name of the branch to merge into (e.g. release/T25.adamwarlock, main)'
         default: release/T25.name
         required: true
 


### PR DESCRIPTION
Set to draft to prevent merging until the repos are all ready to accept the new branch.