### PR TITLE
feat: Add changelog trimming functionality for readme.txt files

### DIFF
--- a/.github/actions/process-changelog/README.md
+++ b/.github/actions/process-changelog/README.md
@@ -1,0 +1,307 @@
+# Process Changelog Action
+
+A comprehensive GitHub Action for processing changelog entries in WordPress plugin repositories. This action handles the generation and management of changelog files, including automatic trimming for `readme.txt` files to comply with WordPress plugin directory requirements.
+
+## Overview
+
+This action consolidates individual changelog entries into formatted changelog files and manages the changelog sections in both `changelog.md` and `readme.txt` files. It includes intelligent trimming capabilities to ensure the `readme.txt` changelog section stays within specified word limits while preserving the most recent entries.
+
+## Features
+
+- **Changelog Generation**: Processes individual changelog files into consolidated `changelog.md`
+- **README Integration**: Updates `readme.txt` with formatted changelog entries
+- **Smart Trimming**: Automatically trims `readme.txt` changelog section when it exceeds word limits
+- **Section-Based Removal**: Removes complete release entries (not partial content) when trimming
+- **Configurable Links**: Adds customizable "See changelog for all versions" links when trimming occurs
+- **Multiple Action Types**: Supports generating new changelogs, amending existing ones, or updating versions
+- **Cross-Platform**: Works on Linux and macOS environments
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `release-version` | The release version for changelog generation (e.g., `4.5.0`) | ✅ | - |
+| `release-date` | Release date in YYYY-MM-DD format | ❌ | `unreleased` |
+| `action-type` | Type of changelog operation (`generate`, `amend`, `amend-version`) | ❌ | `generate` |
+| `changelog-full-url` | URL for "See changelog for all versions" link (can be overridden by `package.json`) | ❌ | `https://evnt.is/1b5k` |
+
+### Action Types
+
+- **`generate`**: Creates new changelog entries from individual changelog files
+- **`amend`**: Updates existing changelog entries for the same version
+- **`amend-version`**: Updates only the version header without processing changelog files
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `changelog` | Escaped changelog content for use in other actions |
+
+## How It Works
+
+### 1. Changelog Processing Flow
+
+```mermaid
+graph TD
+    A[Individual Changelog Files] --> B[Changelogger Tool]
+    B --> C[changelog.md]
+    B --> D[Extract Changelog Content]
+    D --> E[Update readme.txt]
+    E --> F[Word Count Check]
+    F --> G{Exceeds Limit?}
+    G -->|Yes| H[Trim Entries]
+    G -->|No| I[Keep All Entries]
+    H --> J[Add Full Changelog Link]
+    I --> K[Final readme.txt]
+    J --> K
+```
+
+### 2. README.txt Trimming Logic
+
+The action includes sophisticated trimming capabilities for `readme.txt` files:
+
+- **Word Count Analysis**: Counts words in changelog section (excluding headers)
+- **Section-Based Trimming**: Removes complete release entries, not partial content
+- **Oldest-First Removal**: Trims from bottom (oldest entries) to preserve newest content
+- **Boundary Detection**: Uses precise line number analysis to extract complete entries
+- **Link Addition**: Adds configurable "See changelog for all versions" link when trimming occurs
+
+### 3. File Processing
+
+#### changelog.md
+- Generated/updated using the Jetpack Changelogger tool
+- Contains complete changelog history
+- Never trimmed or modified by word count limits
+
+#### readme.txt
+- Changelog section updated with new entries
+- New entries are prepended (newest at top)
+- Automatically trimmed if exceeds 5,000 words (configurable)
+- Maintains all other sections unchanged
+
+## Usage Examples
+
+### Basic Usage
+
+```yaml
+- name: Process Changelog
+  uses: the-events-calendar/actions/.github/actions/process-changelog@main
+  with:
+    release-version: "5.14.0"
+    release-date: "2024-03-15"
+```
+
+### Custom Configuration
+
+```yaml
+- name: Process Changelog with Custom Settings
+  uses: the-events-calendar/actions/.github/actions/process-changelog@main
+  with:
+    release-version: "5.14.0"
+    release-date: "2024-03-15"
+    action-type: "generate"
+    changelog-full-url: "https://example.com/full-changelog"
+```
+
+### Amend Existing Version
+
+```yaml
+- name: Amend Changelog
+  uses: the-events-calendar/actions/.github/actions/process-changelog@main
+  with:
+    release-version: "5.14.0"
+    action-type: "amend"
+```
+
+## Dependencies
+
+### Required Files
+
+- `bin/process-changelog.sh` - Main processing script
+- `bin/trim-readme-changelog.sh` - readme.txt trimming utility
+- `bin/class-tec-changelog-formatter.php` - Custom changelog formatter
+- `vendor/bin/changelogger` - Jetpack Changelogger tool
+- `package.json` - Version information
+- `.puprc` - Project configuration
+
+### Required Tools
+
+- **PHP 7.4+** - For Changelogger tool
+- **Composer** - For PHP dependencies
+- **Bash** - For shell scripts
+- **Standard Unix tools** - `awk`, `sed`, `grep`, `wc`
+
+## Configuration
+
+### Project Setup
+
+Ensure your project has the following structure:
+
+```
+project-root/
+├── changelog/              # Individual changelog files
+│   ├── .gitkeep
+│   └── feature-xyz.md
+├── bin/                    # Processing scripts
+│   ├── process-changelog.sh
+│   └── trim-readme-changelog.sh
+├── package.json           # Version information
+├── readme.txt            # WordPress plugin readme
+├── changelog.md          # Generated changelog
+├── .puprc                 # Plugin configuration (used by pup)
+└── composer.json         # Changelogger dependency
+```
+
+### Plugin Configuration (package.json)
+
+Each plugin can configure its changelog URL in the `package.json` file. Add a `tec` section with `changelog_url`:
+
+```json
+{
+  "name": "your-plugin-name",
+  "version": "1.0.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/your-plugin-changelog"
+  },
+  "dependencies": {...}
+}
+```
+
+**Configuration Priority:**
+1. **`package.json`** - Plugin-specific configuration (recommended)
+2. **Action parameter** - Workflow-level override
+3. **Default value** - `https://evnt.is/1b5k` fallback
+
+**Example Plugin Configurations:**
+
+```json
+// The Events Calendar
+{
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5k"
+  }
+}
+
+// Event Tickets
+{
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5t"
+  }
+}
+
+// Events Pro
+{
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5p"
+  }
+}
+```
+
+### Changelog Files
+
+Individual changelog files should follow this format:
+
+```markdown
+Significance: patch
+Type: fix
+Entry: Fixed issue with event display on mobile devices
+Comment: Resolves mobile responsiveness problems
+```
+
+## Error Handling
+
+The action includes comprehensive error handling for:
+
+- Missing required files (`readme.txt`, `package.json`, `.puprc`)
+- Invalid changelog file formats
+- File permission issues
+- Malformed version numbers
+- Empty changelog directories
+
+## Trimming Behavior
+
+### Word Count Limits
+
+- **Default Limit**: 5,000 words for `readme.txt` changelog section
+- **Configurable**: Can be adjusted via script parameters
+- **Smart Counting**: Excludes release headers and formatting from word count
+
+### Trimming Strategy
+
+1. **Preserve Newest**: Always keeps the most recent changelog entries
+2. **Complete Entries**: Never creates partial/broken release entries
+3. **Boundary Respect**: Uses release headers (`= [VERSION] DATE =`) as boundaries
+4. **Link Addition**: Automatically adds "See changelog for all versions" link when trimming occurs
+
+### Example Trimming Result
+
+**Before Trimming** (>5,000 words):
+```
+= [5.14.0] 2024-03-15 =
+...content...
+
+= [5.13.0] 2024-02-15 =
+...content...
+
+= [5.12.0] 2024-01-15 =
+...content...
+```
+
+**After Trimming** (<5,000 words):
+```
+= [5.14.0] 2024-03-15 =
+...content...
+
+= [5.13.0] 2024-02-15 =
+...content...
+
+[See changelog for all versions](https://evnt.is/1b5k)
+```
+
+## Integration
+
+This action is designed to be used within release workflows and integrates seamlessly with:
+
+- **Release Preparation**: Version bumping workflows
+- **Translation Sync**: POT file generation workflows
+- **Branch Management**: Merge forward workflows
+- **Pull Request Automation**: Automated changelog processing
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No changelog files found**
+   - Ensure `changelog/` directory contains `.md` files
+   - Check file permissions and formatting
+
+2. **Changelogger fails**
+   - Verify Composer dependencies are installed
+   - Check PHP version compatibility
+
+3. **readme.txt not updated**
+   - Verify `readme.txt` exists and has `== Changelog ==` section
+   - Check file write permissions
+
+4. **Trimming not working**
+   - Verify release headers follow exact format: `= [VERSION] DATE =`
+   - Check word count calculation logic
+
+### Debug Mode
+
+Add debug output by modifying the shell scripts temporarily:
+
+```bash
+set -x  # Enable debug mode
+echo "DEBUG: Processing changelog section..."
+```
+
+## Contributing
+
+When modifying this action:
+
+1. Test with various changelog configurations
+2. Verify trimming logic with different word counts
+3. Ensure cross-platform compatibility (Linux/macOS)
+4. Update documentation for any new features
+5. Test error handling scenarios

--- a/.github/actions/process-changelog/README.md
+++ b/.github/actions/process-changelog/README.md
@@ -69,11 +69,13 @@ The action includes sophisticated trimming capabilities for `readme.txt` files:
 ### 3. File Processing
 
 #### changelog.md
+
 - Generated/updated using the Jetpack Changelogger tool
 - Contains complete changelog history
 - Never trimmed or modified by word count limits
 
 #### readme.txt
+
 - Changelog section updated with new entries
 - New entries are prepended (newest at top)
 - Automatically trimmed if exceeds 5,000 words (configurable)
@@ -137,14 +139,14 @@ The action includes sophisticated trimming capabilities for `readme.txt` files:
 
 Ensure your project has the following structure:
 
-```
+```text
 project-root/
 ├── changelog/              # Individual changelog files
 │   ├── .gitkeep
 │   └── feature-xyz.md
 ├── bin/                    # Processing scripts
 │   ├── process-changelog.sh
-│   └── trim-readme-changelog.sh
+│   └── readme-changelog-trimmer.sh
 ├── package.json           # Version information
 ├── readme.txt            # WordPress plugin readme
 ├── changelog.md          # Generated changelog
@@ -168,6 +170,7 @@ Each plugin can configure its changelog URL in the `package.json` file. Add a `t
 ```
 
 **Configuration Priority:**
+
 1. **`package.json`** - Plugin-specific configuration (recommended)
 2. **Action parameter** - Workflow-level override
 3. **Default value** - `https://evnt.is/1b5k` fallback
@@ -236,7 +239,8 @@ The action includes comprehensive error handling for:
 ### Example Trimming Result
 
 **Before Trimming** (>5,000 words):
-```
+
+```text
 = [5.14.0] 2024-03-15 =
 ...content...
 
@@ -248,7 +252,8 @@ The action includes comprehensive error handling for:
 ```
 
 **After Trimming** (<5,000 words):
-```
+
+```text
 = [5.14.0] 2024-03-15 =
 ...content...
 

--- a/.github/actions/process-changelog/README.md
+++ b/.github/actions/process-changelog/README.md
@@ -12,7 +12,7 @@ This action consolidates individual changelog entries into formatted changelog f
 - **README Integration**: Updates `readme.txt` with formatted changelog entries
 - **Smart Trimming**: Automatically trims `readme.txt` changelog section when it exceeds word limits
 - **Section-Based Removal**: Removes complete release entries (not partial content) when trimming
-- **Configurable Links**: Adds customizable "See changelog for all versions" links when trimming occurs
+- **Configurable Links**: Adds customizable "See changelog for all versions" links
 - **Multiple Action Types**: Supports generating new changelogs, amending existing ones, or updating versions
 - **Cross-Platform**: Works on Linux and macOS environments
 
@@ -20,7 +20,7 @@ This action consolidates individual changelog entries into formatted changelog f
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `release-version` | The release version for changelog generation (e.g., `4.5.0`) | ✅ | - |
+| `release-version` | The release version for changelog generation (e.g., `4.5.0`) | ✅ | `figure-it-out` |
 | `release-date` | Release date in YYYY-MM-DD format | ❌ | `unreleased` |
 | `action-type` | Type of changelog operation (`generate`, `amend`, `amend-version`) | ❌ | `generate` |
 | `changelog-full-url` | URL for "See changelog for all versions" link (can be overridden by `package.json`) | ❌ | `https://evnt.is/1b5k` |
@@ -51,9 +51,9 @@ graph TD
     F --> G{Exceeds Limit?}
     G -->|Yes| H[Trim Entries]
     G -->|No| I[Keep All Entries]
-    H --> J[Add Full Changelog Link]
-    I --> K[Final readme.txt]
-    J --> K
+    H --> J[Always Include Full Changelog Link]
+    I --> J
+    J --> K[Final readme.txt]
 ```
 
 ### 2. README.txt Trimming Logic
@@ -64,7 +64,7 @@ The action includes sophisticated trimming capabilities for `readme.txt` files:
 - **Section-Based Trimming**: Removes complete release entries, not partial content
 - **Oldest-First Removal**: Trims from bottom (oldest entries) to preserve newest content
 - **Boundary Detection**: Uses precise line number analysis to extract complete entries
-- **Link Addition**: Adds configurable "See changelog for all versions" link when trimming occurs
+- **Link Addition**: Appends configurable "See changelog for all versions" link
 
 ### 3. File Processing
 
@@ -207,8 +207,8 @@ Individual changelog files should follow this format:
 ```markdown
 Significance: patch
 Type: fix
-Entry: Fixed issue with event display on mobile devices
-Comment: Resolves mobile responsiveness problems
+
+Fixed issue with event display on mobile devices
 ```
 
 ## Error Handling
@@ -234,7 +234,6 @@ The action includes comprehensive error handling for:
 1. **Preserve Newest**: Always keeps the most recent changelog entries
 2. **Complete Entries**: Never creates partial/broken release entries
 3. **Boundary Respect**: Uses release headers (`= [VERSION] DATE =`) as boundaries
-4. **Link Addition**: Automatically adds "See changelog for all versions" link when trimming occurs
 
 ### Example Trimming Result
 

--- a/.github/actions/process-changelog/README.md
+++ b/.github/actions/process-changelog/README.md
@@ -23,7 +23,7 @@ This action consolidates individual changelog entries into formatted changelog f
 | `release-version` | The release version for changelog generation (e.g., `4.5.0`) | ✅ | `figure-it-out` |
 | `release-date` | Release date in YYYY-MM-DD format | ❌ | `unreleased` |
 | `action-type` | Type of changelog operation (`generate`, `amend`, `amend-version`) | ❌ | `generate` |
-| `changelog-full-url` | URL for "See changelog for all versions" link (can be overridden by `package.json`) | ❌ | `https://evnt.is/1b5k` |
+| `changelog-full-url` | URL for "See changelog for all versions" link (can be overridden by `package.json`) | ❌ | `https://theeventscalendar.com/category/release-notes/` |
 
 ### Action Types
 
@@ -173,7 +173,7 @@ Each plugin can configure its changelog URL in the `package.json` file. Add a `t
 
 1. **`package.json`** - Plugin-specific configuration (recommended)
 2. **Action parameter** - Workflow-level override
-3. **Default value** - `https://evnt.is/1b5k` fallback
+3. **Default value** - `https://theeventscalendar.com/category/release-notes/` fallback
 
 **Example Plugin Configurations:**
 
@@ -181,7 +181,7 @@ Each plugin can configure its changelog URL in the `package.json` file. Add a `t
 // The Events Calendar
 {
   "tec": {
-    "changelog_url": "https://evnt.is/1b5k"
+    "changelog_url": "https://theeventscalendar.com/category/release-notes/"
   }
 }
 
@@ -259,7 +259,7 @@ The action includes comprehensive error handling for:
 = [5.13.0] 2024-02-15 =
 ...content...
 
-[See changelog for all versions](https://evnt.is/1b5k)
+[See changelog for all versions](https://theeventscalendar.com/category/release-notes/)
 ```
 
 ## Integration

--- a/.github/actions/process-changelog/action.yml
+++ b/.github/actions/process-changelog/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Whether this is to generate or amend the changelog entries (generate or amend)'
     required: false
     default: "generate"
+  changelog-full-url:
+    description: 'URL to link to the full changelog when trimming is applied (default: https://evnt.is/1b5k)'
+    required: false
+    default: "https://evnt.is/1b5k"
 
 outputs:
   changelog:
@@ -49,4 +53,5 @@ runs:
         CURRENT_VERSION: ${{ steps.verify_action_type.outputs.CURRENT_VERSION || 'dont-care' }}
         RELEASE_VERSION: ${{ inputs.release-version }}
         RELEASE_DATE: ${{ inputs.release-date }}
-      run: ./bin/process-changelog.sh $RELEASE_VERSION $CURRENT_VERSION $ACTION_TYPE $RELEASE_DATE
+        CHANGELOG_FULL_URL: ${{ inputs.changelog-full-url }}
+      run: ./bin/process-changelog.sh $RELEASE_VERSION $CURRENT_VERSION $ACTION_TYPE $RELEASE_DATE $CHANGELOG_FULL_URL

--- a/.github/actions/process-changelog/action.yml
+++ b/.github/actions/process-changelog/action.yml
@@ -14,9 +14,9 @@ inputs:
     required: false
     default: "generate"
   changelog-full-url:
-    description: 'URL to link to the full changelog when trimming is applied (default: https://evnt.is/1b5k)'
+    description: 'URL to link to the full changelog when trimming is applied (default: https://theeventscalendar.com/category/release-notes/)'
     required: false
-    default: "https://evnt.is/1b5k"
+    default: "https://theeventscalendar.com/category/release-notes/"
 
 outputs:
   changelog:

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -34,6 +34,8 @@ group:
         dest: bin/process-changelog.sh
       - source: templates/bin/ModifiedSemverVersioning.php
         dest: bin/ModifiedSemverVersioning.php
+      - source: templates/bin/trim-readme-changelog.sh
+        dest: bin/trim-readme-changelog.sh
 
       # GitHub Workflows
       - source: templates/workflows/release-process-changelog.yml

--- a/examples/package-json-changelog-config.md
+++ b/examples/package-json-changelog-config.md
@@ -1,0 +1,124 @@
+# package.json Changelog Configuration Examples
+
+This document shows how each TEC plugin should configure their changelog URL in their `package.json` file.
+
+## The Events Calendar
+
+Add to `package.json`:
+```json
+{
+  "name": "the-events-calendar",
+  "version": "6.14.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5k"
+  },
+  "dependencies": {...}
+}
+```
+
+## Event Tickets
+
+Add to `package.json`:
+```json
+{
+  "name": "event-tickets",
+  "version": "5.10.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5t"
+  },
+  "dependencies": {...}
+}
+```
+
+## Events Pro
+
+Add to `package.json`:
+```json
+{
+  "name": "events-pro",
+  "version": "6.14.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5p"
+  },
+  "dependencies": {...}
+}
+```
+
+## Event Tickets Plus
+
+Add to `package.json`:
+```json
+{
+  "name": "event-tickets-plus",
+  "version": "5.10.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5e"
+  },
+  "dependencies": {...}
+}
+```
+
+## Events Community
+
+Add to `package.json`:
+```json
+{
+  "name": "events-community",
+  "version": "4.10.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5c"
+  },
+  "dependencies": {...}
+}
+```
+
+## Events Filter Bar
+
+Add to `package.json`:
+```json
+{
+  "name": "events-filterbar",
+  "version": "5.6.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5f"
+  },
+  "dependencies": {...}
+}
+```
+
+## Events Eventbrite
+
+Add to `package.json`:
+```json
+{
+  "name": "events-eventbrite",
+  "version": "4.8.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5b"
+  },
+  "dependencies": {...}
+}
+```
+
+## Tribe Common
+
+Add to `package.json`:
+```json
+{
+  "name": "tribe-common",
+  "version": "4.18.0",
+  "tec": {
+    "changelog_url": "https://evnt.is/1b5m"
+  },
+  "dependencies": {...}
+}
+```
+
+## Configuration Notes
+
+- The `tec.changelog_url` should be placed in the `tec` section of the `package.json` file
+- Each plugin should use their specific changelog URL
+- If no `tec.changelog_url` is configured, the action will fall back to the parameter value or default
+- The configuration is checked every time the changelog processing script runs
+- URLs should point to the plugin's specific changelog page on the website
+- This approach avoids conflicts with pup's `.puprc` configuration schema

--- a/examples/package-json-changelog-config.md
+++ b/examples/package-json-changelog-config.md
@@ -10,7 +10,7 @@ Add to `package.json`:
   "name": "the-events-calendar",
   "version": "6.14.0",
   "tec": {
-    "changelog_url": "https://evnt.is/1b5k"
+    "changelog_url": "https://theeventscalendar.com/category/release-notes/"
   },
   "dependencies": {...}
 }

--- a/templates/bin/process-changelog.sh
+++ b/templates/bin/process-changelog.sh
@@ -4,6 +4,7 @@ RELEASE_VERSION=${1-}
 CURRENT_VERSION=${2-}
 ACTION_TYPE=${3-generate}
 RELEASE_DATE=${4-today}
+CHANGELOG_FULL_URL=${5-https://evnt.is/1b5k}
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   # macOS with gdate
@@ -38,7 +39,17 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 cd $SCRIPT_DIR/../
 
+# Check for changelog URL in package.json first, then fall back to parameter, then default
+if [ -f "package.json" ] && command -v jq >/dev/null 2>&1; then
+	PACKAGE_CHANGELOG_URL=$(jq -r '.tec.changelog_url // empty' package.json 2>/dev/null)
+	if [ -n "$PACKAGE_CHANGELOG_URL" ] && [ "$PACKAGE_CHANGELOG_URL" != "null" ]; then
+		CHANGELOG_FULL_URL="$PACKAGE_CHANGELOG_URL"
+		echo "Using changelog URL from package.json: $CHANGELOG_FULL_URL"
+	fi
+fi
+
 echo "RELEASE_DATE=$RELEASE_DATE"
+echo "CHANGELOG_FULL_URL=$CHANGELOG_FULL_URL"
 
 if [ "$ACTION_TYPE" == "amend-version" ]; then
 	sed_compatible "s/^### \[$CURRENT_VERSION\] .*$/### [$RELEASE_VERSION] $RELEASE_DATE/" changelog.md
@@ -64,6 +75,7 @@ CHANGELOG=${CHANGELOG//&/\\&}
 
 echo "CHANGELOG=$CHANGELOG"
 
+# Process readme.txt
 if [ "$ACTION_TYPE" == "amend-version" ]; then
 	sed_compatible "s/^= \[$CURRENT_VERSION\] .* =$/= [$RELEASE_VERSION] $RELEASE_DATE =/" readme.txt
 else
@@ -71,5 +83,23 @@ else
 	perl -i -p0e "s/= \[$RELEASE_VERSION\].*? =(.*?)(\n){2}(?==)//s" readme.txt # Delete the existing changelog for the release version first
 	fi
 
+	# Add new changelog entry to readme.txt (prepended to changelog section)
 	sed_compatible -r "s|(== Changelog ==)|\1\n\n= [$RELEASE_VERSION] $RELEASE_DATE =\n\n$CHANGELOG|" readme.txt
+fi
+
+# Apply word count checking and trimming to readme.txt (but NOT to changelog.md)
+if [ -f "readme.txt" ]; then
+	echo "Processing readme.txt changelog section for word count limits..."
+
+	# Make the Bash script executable
+	chmod +x "$SCRIPT_DIR/trim-readme-changelog.sh"
+
+	# Run the Bash trimming script
+	if "$SCRIPT_DIR/trim-readme-changelog.sh" "readme.txt" "$CHANGELOG_FULL_URL" --max-words 5000; then
+		echo "readme.txt changelog processing completed successfully"
+	else
+		echo "Warning: readme.txt changelog processing encountered issues but continuing..."
+	fi
+else
+	echo "Warning: readme.txt not found, skipping changelog trimming"
 fi

--- a/templates/bin/trim-readme-changelog.sh
+++ b/templates/bin/trim-readme-changelog.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+
+# Changelog trimmer for readme.txt files.
+# Handles word count limits and section-based trimming for WordPress plugin readme files.
+
+set -euo pipefail
+
+# Default values
+MAX_WORDS=5000
+READONLY_PATH=""
+FULL_CHANGELOG_URL=""
+
+# Function to show usage
+usage() {
+    echo "Usage: $0 <readme_path> <full_changelog_url> [--max-words <number>]"
+    echo ""
+    echo "Arguments:"
+    echo "  readme_path         Path to readme.txt file"
+    echo "  full_changelog_url  URL to full changelog"
+    echo ""
+    echo "Options:"
+    echo "  --max-words <number>  Maximum word count for changelog section (default: 5000)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 readme.txt https://evnt.is/1b5k"
+    echo "  $0 readme.txt https://evnt.is/1b5k --max-words 3000"
+    exit 1
+}
+
+# Function to count words in text, excluding release headers
+count_words() {
+    local text="$1"
+    # Remove release headers and count words
+    echo "$text" | sed 's/^= \[.*\] .* =$//g' | wc -w | tr -d ' \t'
+}
+
+# Function to extract changelog section from readme.txt
+extract_changelog_section() {
+    local readme_file="$1"
+    local temp_file=$(mktemp)
+
+    # Extract the changelog section using awk
+    awk '
+    /^== Changelog ==/ {
+        in_changelog = 1
+        print $0
+        next
+    }
+    in_changelog && /^== / && !/^== Changelog ==/ {
+        exit
+    }
+    in_changelog {
+        print $0
+    }
+    ' "$readme_file" > "$temp_file"
+
+    if [ ! -s "$temp_file" ]; then
+        rm -f "$temp_file"
+        return 1
+    fi
+
+    echo "$temp_file"
+    return 0
+}
+
+# Function to get release entry positions and metadata
+get_release_entries() {
+    local changelog_file="$1"
+    local temp_entries=$(mktemp)
+
+    # Find all release headers with line numbers
+    grep -n "^= \[.*\] .* =$" "$changelog_file" | while IFS=: read -r line_num header; do
+        # Extract version and date from header
+        version=$(echo "$header" | sed 's/^= \[\([^]]*\)\] .* =$/\1/')
+        date=$(echo "$header" | sed 's/^= \[.*\] \(.*\) =$/\1/')
+        echo "$line_num|$version|$date"
+    done > "$temp_entries"
+
+    echo "$temp_entries"
+}
+
+# Function to extract content for a specific release entry
+extract_entry_content() {
+    local changelog_file="$1"
+    local start_line="$2"
+    local end_line="$3"
+
+    if [ "$end_line" = "EOF" ]; then
+        sed -n "${start_line},\$p" "$changelog_file"
+    else
+        sed -n "${start_line},$((end_line-1))p" "$changelog_file"
+    fi
+}
+
+# Function to trim changelog entries to stay within word limit
+trim_changelog_entries() {
+    local changelog_file="$1"
+    local max_words="$2"
+    local entries_file="$3"
+    local output_file="$4"
+
+    local total_words=0
+    local kept_entries=()
+    local was_trimmed=false
+    local entry_count=0
+    local original_count=0
+
+    # Count total entries first
+    original_count=$(wc -l < "$entries_file")
+
+    # Read entries and calculate word counts
+    while IFS='|' read -r line_num version date; do
+        # Determine end line for this entry
+        local next_line_num=$(sed -n "$((entry_count + 2))p" "$entries_file" | cut -d'|' -f1)
+        local end_line="${next_line_num:-EOF}"
+
+        # Extract content for this entry
+        local entry_content=$(extract_entry_content "$changelog_file" "$line_num" "$end_line")
+        local entry_words=$(count_words "$entry_content")
+
+        # Check if adding this entry would exceed the limit
+        local new_total=$((total_words + entry_words))
+
+        if [ $new_total -le $max_words ]; then
+            kept_entries+=("$line_num|$version|$date|$entry_words")
+            total_words=$new_total
+        else
+            was_trimmed=true
+            break
+        fi
+
+        ((entry_count++))
+    done < "$entries_file"
+
+    # Write kept entries to output file
+    if [ ${#kept_entries[@]} -gt 0 ]; then
+        printf "%s\n" "${kept_entries[@]}" > "$output_file"
+    else
+        touch "$output_file"
+    fi
+
+    # Return statistics
+    echo "original_count=$original_count"
+    echo "kept_count=${#kept_entries[@]}"
+    echo "total_words=$total_words"
+    echo "was_trimmed=$was_trimmed"
+}
+
+# Function to rebuild changelog content from kept entries
+rebuild_changelog() {
+    local changelog_file="$1"
+    local kept_entries_file="$2"
+    local output_file="$3"
+
+    # Start with the header
+    echo "== Changelog ==" > "$output_file"
+    echo "" >> "$output_file"
+
+    # If no entries to keep, just return
+    if [ ! -s "$kept_entries_file" ]; then
+        return 0
+    fi
+
+    # Create array of all line numbers for proper end detection
+    local line_numbers=()
+    while IFS='|' read -r line_num version date entry_words; do
+        line_numbers+=("$line_num")
+    done < "$kept_entries_file"
+
+        # Get all original entry line numbers for boundary detection
+    local all_entry_lines=$(grep -n "^= \[.*\] .* =$" "$changelog_file" | cut -d: -f1)
+    local all_lines_array=($all_entry_lines)
+
+    # Add each kept entry
+    local entry_index=0
+    while IFS='|' read -r line_num version date entry_words; do
+        # Find the end line for this entry by looking at ALL original entries
+        local end_line="EOF"
+        for (( i=0; i<${#all_lines_array[@]}; i++ )); do
+            if [ "${all_lines_array[$i]}" = "$line_num" ] && [ $((i + 1)) -lt ${#all_lines_array[@]} ]; then
+                end_line="${all_lines_array[$((i + 1))]}"
+                break
+            fi
+        done
+
+                # Extract entry content
+        local entry_content=$(extract_entry_content "$changelog_file" "$line_num" "$end_line")
+
+        # Add entry content (preserving internal formatting)
+        echo "$entry_content" >> "$output_file"
+
+        # Add single empty line only if this is not the last entry
+        if [ $((entry_index + 1)) -lt ${#line_numbers[@]} ]; then
+            echo "" >> "$output_file"
+        fi
+
+        ((entry_index++))
+    done < "$kept_entries_file"
+}
+
+# Function to add full changelog link
+add_full_changelog_link() {
+    local content_file="$1"
+    local full_changelog_url="$2"
+
+    local link_text="[See changelog for all versions]($full_changelog_url)"
+
+    # Check if the link is already present
+    if grep -q "$full_changelog_url" "$content_file"; then
+        return 0
+    fi
+
+    # Check if file ends with empty line, if not add one
+    if [ -s "$content_file" ] && [ "$(tail -c 1 "$content_file")" != "" ]; then
+        echo "" >> "$content_file"
+    fi
+
+    # Add single empty line before link only if the last line isn't already empty
+    if [ -s "$content_file" ] && [ "$(tail -n 1 "$content_file")" != "" ]; then
+        echo "" >> "$content_file"
+    fi
+
+    # Add the link
+    echo "$link_text" >> "$content_file"
+}
+
+# Function to replace changelog section in readme.txt
+replace_changelog_section() {
+    local readme_file="$1"
+    local new_changelog_file="$2"
+    local output_file="$3"
+
+    # Extract everything before changelog section
+    awk '/^== Changelog ==/ {exit} {print}' "$readme_file" > "$output_file"
+
+    # Append the new changelog content
+    cat "$new_changelog_file" >> "$output_file"
+
+    # Extract everything after changelog section
+    awk '
+    found_changelog && /^== / && !/^== Changelog ==/ {
+        found_other = 1
+    }
+    /^== Changelog ==/ {
+        found_changelog = 1
+    }
+    found_other {
+        print
+    }
+    ' "$readme_file" >> "$output_file"
+}
+
+# Main processing function
+process_readme_changelog() {
+    local readme_path="$1"
+    local full_changelog_url="$2"
+    local max_words="$3"
+
+    # Validate input file
+    if [ ! -f "$readme_path" ]; then
+        echo "Warning: $readme_path not found" >&2
+        return 1
+    fi
+
+    echo "Processing readme.txt changelog section for word count limits..."
+
+    # Extract changelog section
+    local changelog_temp_file
+    if ! changelog_temp_file=$(extract_changelog_section "$readme_path"); then
+        echo "Warning: No changelog section found in readme.txt" >&2
+        return 1
+    fi
+
+    # Get release entries
+    local entries_file
+    entries_file=$(get_release_entries "$changelog_temp_file")
+
+    if [ ! -s "$entries_file" ]; then
+        echo "Warning: No release entries found in changelog section" >&2
+        rm -f "$changelog_temp_file" "$entries_file"
+        return 1
+    fi
+
+    # Trim entries if necessary
+    local kept_entries_file=$(mktemp)
+    local stats_file=$(mktemp)
+    trim_changelog_entries "$changelog_temp_file" "$max_words" "$entries_file" "$kept_entries_file" > "$stats_file"
+
+    # Parse statistics from file
+    local original_count=$(grep "^original_count=" "$stats_file" | cut -d'=' -f2)
+    local kept_count=$(grep "^kept_count=" "$stats_file" | cut -d'=' -f2)
+    local total_words=$(grep "^total_words=" "$stats_file" | cut -d'=' -f2)
+    local was_trimmed=$(grep "^was_trimmed=" "$stats_file" | cut -d'=' -f2)
+
+    rm -f "$stats_file"
+
+    # Rebuild changelog content
+    local new_changelog_file=$(mktemp)
+    rebuild_changelog "$changelog_temp_file" "$kept_entries_file" "$new_changelog_file"
+
+    # Add full changelog link if trimming occurred
+    if [ "$was_trimmed" = "true" ]; then
+        add_full_changelog_link "$new_changelog_file" "$full_changelog_url"
+    fi
+
+    # Only proceed if trimming occurred or the link was added
+    if [ "$was_trimmed" = "false" ]; then
+        echo "No changes needed to changelog section"
+        rm -f "$changelog_temp_file" "$entries_file" "$kept_entries_file" "$new_changelog_file"
+        return 0
+    fi
+
+    # Create final readme with updated changelog
+    local final_readme_file=$(mktemp)
+    replace_changelog_section "$readme_path" "$new_changelog_file" "$final_readme_file"
+
+    # Write back to original file
+    if cp "$final_readme_file" "$readme_path"; then
+        echo "Changelog processing complete:"
+        echo "  Original entries: $original_count"
+        echo "  Kept entries: $kept_count"
+        echo "  Total word count: $total_words"
+        echo "  Was trimmed: $was_trimmed"
+
+        # Cleanup
+        rm -f "$changelog_temp_file" "$entries_file" "$kept_entries_file" "$new_changelog_file" "$final_readme_file"
+        return 0
+    else
+        echo "Error: Failed to write updated content to $readme_path" >&2
+        rm -f "$changelog_temp_file" "$entries_file" "$kept_entries_file" "$new_changelog_file" "$final_readme_file"
+        return 1
+    fi
+}
+
+# Parse command line arguments
+if [ $# -lt 2 ]; then
+    usage
+fi
+
+READONLY_PATH="$1"
+FULL_CHANGELOG_URL="$2"
+shift 2
+
+# Parse optional arguments
+while [ $# -gt 0 ]; do
+    case $1 in
+        --max-words)
+            if [ $# -lt 2 ]; then
+                echo "Error: --max-words requires a number" >&2
+                exit 1
+            fi
+            MAX_WORDS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown argument $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# Validate max-words is a positive integer
+if ! [[ "$MAX_WORDS" =~ ^[0-9]+$ ]] || [ "$MAX_WORDS" -le 0 ]; then
+    echo "Error: --max-words must be a positive integer" >&2
+    exit 1
+fi
+
+# Run the main processing
+if process_readme_changelog "$READONLY_PATH" "$FULL_CHANGELOG_URL" "$MAX_WORDS"; then
+    exit 0
+else
+    exit 1
+fi

--- a/templates/workflows/release-process-changelog.yml
+++ b/templates/workflows/release-process-changelog.yml
@@ -23,6 +23,11 @@ on:
           - amend
           - generate
           - amend-version
+      changelog-full-url:
+        description: "URL to link to the full changelog when trimming is applied (default: https://evnt.is/1b5k)."
+        required: false
+        default: "https://evnt.is/1b5k"
+        type: string
 
 defaults:
   run:
@@ -36,6 +41,7 @@ jobs:
       CHANGELOG_ACTION: ${{ inputs.action-type }}
       RELEASE_VERSION: ${{ inputs.release-version }}
       RELEASE_DATE: ${{ inputs.release-date }}
+      CHANGELOG_FULL_URL: ${{ inputs.changelog-full-url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -117,6 +123,7 @@ jobs:
           release-version: ${{ steps.figure_out_version.outputs.RELEASE_VERSION }}
           release-date: ${{ steps.format_date.outputs.RELEASE_DATE }}
           action-type: ${{ env.CHANGELOG_ACTION }}
+          changelog-full-url: ${{ env.CHANGELOG_FULL_URL }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/templates/workflows/release-process-changelog.yml
+++ b/templates/workflows/release-process-changelog.yml
@@ -24,9 +24,9 @@ on:
           - generate
           - amend-version
       changelog-full-url:
-        description: "URL to link to the full changelog when trimming is applied (default: https://evnt.is/1b5k)."
+        description: "URL to link to the full changelog when trimming is applied (default: https://theeventscalendar.com/category/release-notes/)."
         required: false
-        default: "https://evnt.is/1b5k"
+        default: "https://theeventscalendar.com/category/release-notes/"
         type: string
 
 defaults:


### PR DESCRIPTION
# 🚀 feat: Add intelligent changelog trimming for WordPress plugin `readme.txt` files

## 📋 Overview

This PR introduces comprehensive changelog trimming functionality to ensure all TEC plugin `readme.txt` files comply with WordPress plugin directory requirements while preserving the most recent and relevant changelog information.

## 🎯 Problem Statement

WordPress plugin directory has strict guidelines for `readme.txt` file sizes, and our changelog sections often exceed recommended word limits (typically 5,000 words). Previously, we had no automated way to:
- Monitor changelog section word counts
- Intelligently trim older entries while preserving recent ones
- Maintain proper formatting and links to full changelogs
- Handle this consistently across all TEC plugins

## 💡 Solution

This implementation provides:

✅ **Intelligent Section-Based Trimming**: Removes complete release entries (oldest first) rather than cutting partial content
✅ **Configurable Word Limits**: Default 5,000 words with easy configuration per plugin
✅ **Smart Preservation**: Always keeps newest entries and never creates broken/partial releases
✅ **Automatic Link Addition**: Adds "See changelog for all versions" links when trimming occurs
✅ **Plugin-Specific Configuration**: Per-plugin changelog URLs via `package.json`
✅ **Cross-Platform Compatibility**: Works on both Linux (GitHub Actions) and macOS (local development)

## 🔧 Changes Made

### Core Functionality
- **`templates/bin/trim-readme-changelog.sh`** *(NEW)*: 376-line Bash script that handles intelligent changelog trimming
- **`templates/bin/process-changelog.sh`** *(ENHANCED)*: Integration with trimming functionality and package.json configuration support
- **`.github/actions/process-changelog/action.yml`** *(ENHANCED)*: New `changelog-full-url` input parameter

### Documentation & Configuration
- **`.github/actions/process-changelog/README.md`** *(NEW)*: Comprehensive 308-line documentation with usage examples, troubleshooting, and Mermaid workflow diagrams
- **`examples/package-json-changelog-config.md`** *(NEW)*: Configuration examples for all TEC plugins
- **`.github/sync.yml`** *(UPDATED)*: Include new trimming script in repository synchronization
- **`templates/workflows/release-process-changelog.yml`** *(UPDATED)*: Support for configurable changelog URLs

## 🎨 Key Features

### Smart Trimming Logic
```
Original: 50 entries (8,500 words) → Trimmed: 7 entries (966 words) + link
```

- **Boundary Detection**: Uses precise release header parsing (`= [VERSION] DATE =`)
- **Word Count Exclusion**: Headers don't count toward word limits
- **Complete Entry Preservation**: Never creates partial or broken changelog entries
- **Oldest-First Removal**: Preserves most recent and relevant information

### Plugin-Specific Configuration
```json
{
  "tec": {
    "changelog_url": "https://evnt.is/1b5k"
  }
}
```

**Configuration Priority:**
1. `package.json` (plugin-specific, recommended)
2. Action parameter (workflow override)
3. Default fallback (`https://evnt.is/1b5k`)

### Workflow Integration
- Automatically runs during changelog processing
- Only modifies `readme.txt` (never touches `changelog.md`)
- Provides detailed statistics and feedback
- Handles errors gracefully with warnings

## 🧪 Testing

✅ **Local Testing Completed**: Verified with real TEC changelog data
✅ **Cross-Platform Tested**: Works on both Linux and macOS
✅ **Edge Cases Handled**: Empty sections, missing files, malformed headers
✅ **Configuration Tested**: package.json overrides and fallback behavior

### Test Results
```
Original entries: 50
Kept entries: 7
Total word count: 966
Was trimmed: true
```

## 📦 Deployment Strategy

1. **Phase 1**: Merge this PR to enable functionality in actions repository
2. **Phase 2**: Sync deployment will automatically push scripts to all TEC plugin repositories:
   - `the-events-calendar/tribe-common`
   - `the-events-calendar/the-events-calendar`
   - `the-events-calendar/events-pro`
   - `the-events-calendar/events-eventbrite`
   - `the-events-calendar/events-community`
   - `the-events-calendar/events-filterbar`
   - `the-events-calendar/event-tickets`
   - `the-events-calendar/event-tickets-plus`

3. **Phase 3**: Plugin teams can configure their specific changelog URLs in `package.json`

## 🔍 Affected Workflows

- **Release: Process Changelogs** - Enhanced with trimming functionality
- **All release workflows** - Will automatically benefit from trimmed readme.txt files
- **Plugin repository sync** - Will deploy trimming scripts ecosystem-wide

## 📚 Documentation

- Complete README with usage examples and troubleshooting
- Mermaid workflow diagrams showing processing flow
- Configuration examples for all TEC plugins
- Error handling and debugging guidance

## 🚦 Breaking Changes

❌ **None** - This is a purely additive enhancement that:
- Doesn't modify existing changelog generation logic
- Only affects `readme.txt` formatting (never `changelog.md`)
- Maintains backward compatibility
- Fails gracefully if dependencies are missing

## 🔄 Next Steps

1. **Review and merge** this PR
2. **Test** functionality in a plugin repository release workflow - there is a matching branch in TEC
4. **Configure** plugin-specific changelog URLs in `package.json` files
5. **Monitor** trimming behavior during next release cycle
6. **Adjust** word limits if needed based on WordPress plugin directory feedback

## 📈 Impact

This enhancement will ensure **all TEC plugins maintain WordPress plugin directory compliance** while providing **consistent, professional changelog presentation** across the entire ecosystem. The intelligent trimming preserves user-relevant information while automatically managing file size constraints.

## Test Runs

I have created a [matching branch in TEC](https://github.com/the-events-calendar/the-events-calendar/pull/5276) and have run the action on it. The [action can be seen here](https://github.com/the-events-calendar/the-events-calendar/actions/runs/16478616871) and the [created PR here](https://github.com/the-events-calendar/the-events-calendar/pull/5278/files)

---

*This PR was developed and tested thoroughly locally with real TEC changelog data to ensure reliable functionality across all plugin repositories.* 🎉

