### PR TITLE
Fix merge-forward failing on submodule merges

### DIFF
--- a/templates/workflows/release-merge-forward.yml
+++ b/templates/workflows/release-merge-forward.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.forward-branch }}
           fetch-depth: 0
+          submodules: recursive
 
       - name: Set up Git configuration
         run: |
@@ -56,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Set up Git configuration
         run: |


### PR DESCRIPTION
## What this does

Fixes the \`Release: Merge Forward\` action failing with:
\`\`\`
Failed to merge submodule common (not checked out)
CONFLICT (submodule): Merge conflict in common
\`\`\`

## Root cause

Both checkout steps omit \`submodules: recursive\`, so \`common/\` is empty on the runner. Git can't resolve even a trivial fast-forward for the submodule pointer without the submodule's own history physically present locally, so every merge involving a submodule pointer bump turns into a conflict requiring manual resolution.

Confirmed this is a real fast-forward case, not a genuine divergence: for both \`event-tickets\` and \`the-events-calendar\`, \`main\`'s \`common\` pointer is an ancestor of both \`bucket/rsvp-merge\`'s and \`release/M26.lanturn\`'s pointers.

## Fix

Add \`submodules: recursive\` to both checkout steps.